### PR TITLE
Fix worker indexing

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -20,10 +20,11 @@ node[:deploy].each do |application, deploy|
   settings = node[:resque][application]
   # configure rails_env in case of non-rails app
   rack_env = deploy[:rails_env] || settings[:rack_env] || settings[:rails_env]
+  idx = 0
   settings[:workers].each do |queue, quantity|
 
-    quantity.times do |idx|
-      idx = idx + 1 # make index 1-based
+    quantity.times do
+      idx += 1 # make index 1-based
       template "/etc/init/resque-#{application}-#{idx}.conf" do
         source "resque-n.conf.erb"
         mode '0644'


### PR DESCRIPTION
For json:

```
"resque": {
  "app-name": {
    "workers": {
      "queue1": 1,
      "queue2": 1
    }
  }
}
```

there is `resque-app-name-1.conf` created in `/etc/init` for `"queue1": 1` which is later overwritten by `"queue2": 2`.

This PR fixes worker indexing so there is:
- `resque-app-name-1.conf` created for `"queue1": 1`
- and `resque-app-name-2.conf` created for `"queue2": 1`
